### PR TITLE
Find the results dir based on the example script file location.

### DIFF
--- a/examples/ready_to_run/processing_example.py
+++ b/examples/ready_to_run/processing_example.py
@@ -157,8 +157,10 @@ def main():
     ]
 
     # run the scenarios on a whole result using multiple processes
+    results_dir = _pl.Path(__file__).parent / "data" / "results"
+
     simulations_data = api.process_whole_result_set_parallel(
-        _pl.Path(api.REPO_ROOT / "examples/ready_to_run/data/results"),
+        results_dir,
         processing_scenarios,
     )
 
@@ -168,10 +170,7 @@ def main():
     # run the single scenario on a single simulation
     (
         api.process_single_simulation(
-            _pl.Path(
-                api.REPO_ROOT
-                / "examples/ready_to_run/data/results/complete-0-SnkScale0.8000-StoreScale10"
-            ),
+            results_dir / "complete-0-SnkScale0.8000-StoreScale10",
             # ===============================================================
             processing_for_histogram,
             # do not add round brackets when linking your processing step


### PR DESCRIPTION
When dong `pip install pytrnsys-process` in a fresh environment and then running the `processing_example.py` script from somewhere else (git clone of the source repo, unrelated to my new `venv` into which I've "pip installed" `pytrnsys-process`) then I get the following error

```powershell
(venv) PS C:\Users\damian.birchler\dev\pytrnsys-process-pypi-test> python C:\Users\damian.birchler\src\pytrnsys\wd1\pytrnsys_process\examples\ready_to_run\processing_example.py
Traceback (most recent call last):
  File "C:\Users\damian.birchler\src\pytrnsys\wd1\pytrnsys_process\examples\ready_to_run\processing_example.py", line 186, in <module>
    main()
  File "C:\Users\damian.birchler\src\pytrnsys\wd1\pytrnsys_process\examples\ready_to_run\processing_example.py", line 160, in main
    simulations_data = api.process_whole_result_set_parallel(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\damian.birchler\dev\pytrnsys-process-pypi-test\venv\Lib\site-packages\pytrnsys_process\process\process_batch.py", line 348, in process_whole_result_set_parallel
    _validate_folder(results_folder)
  File "C:\Users\damian.birchler\dev\pytrnsys-process-pypi-test\venv\Lib\site-packages\pytrnsys_process\process\process_batch.py", line 472, in _validate_folder
    raise ValueError(f"Folder does not exist: {folder}")
ValueError: Folder does not exist: C:\Users\damian.birchler\dev\pytrnsys-process-pypi-test\venv\Lib\site-packages\examples\ready_to_run\data\results
```

This is because the script assumes that the directory layout is as it would be in a developer install. I've changed the paths of the script so that it should work independently of how/where it is run.

However, I've not checked whether this still works in a development install. Furthermore, I'm not sure if `api.REPO_ROOT` is still needed now? Maybe not and it can be removed? I know it's still referenced in some places, but I mean whether it's still neded theoretically or whether it could be refactored away. I don't mind it being there, just that having removed one reference now, I wanted you to double check.

Cheers