### PR TITLE
107-conflicting-time-columns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytrnsys_process"
-version = "0.0.23"
+version = "0.0.24"
 authors = [
     { name="Sebastian Swoboda", email="sebastian@swoboda.ch" },
     { name="Alex Hobé", email="alex.hobe@ost.ch" },

--- a/pytrnsys_process/process/process_sim.py
+++ b/pytrnsys_process/process/process_sim.py
@@ -75,6 +75,7 @@ def handle_duplicate_columns(df: _pd.DataFrame) -> _pd.DataFrame:
     ____
     https://stackoverflow.com/questions/14984119/python-pandas-remove-duplicate-columns
     """
+    remove_time_as_well = False
     for col in df.columns[df.columns.duplicated(keep=False)]:
         duplicate_cols = df.iloc[:, df.columns == col]
 
@@ -86,11 +87,20 @@ def handle_duplicate_columns(df: _pd.DataFrame) -> _pd.DataFrame:
             )
 
         if not duplicate_cols.apply(lambda x: x.nunique() <= 1, axis=1).all():
+            if col == "Time":
+                remove_time_as_well = True
+                continue
+
             raise ValueError(
                 f"Column '{col}' has conflicting values at same indices"
             )
 
-    df = df.iloc[:, ~df.columns.duplicated()].copy()
+    columns_to_be_removed = df.columns.duplicated()
+    if remove_time_as_well:
+        columns_to_be_removed += df.columns.get_loc("Time")  # type: ignore[arg-type]
+
+    df = df.iloc[:, ~columns_to_be_removed].copy()
+
     return df
 
 

--- a/tests/pytrnsys_process/test_process_sim.py
+++ b/tests/pytrnsys_process/test_process_sim.py
@@ -110,6 +110,20 @@ class TestHandleDuplicateColumns:
         ):
             ps.handle_duplicate_columns(_pd.concat([df1, df2, df3], axis=1))
 
+    def test_handle_with_conflicting_time_duplicates(self):
+        """Test that conflicting values of the Time column are kicked out, when the import printer column is correct."""
+        df1 = _pd.DataFrame({"Period": [1, 2], "Time": [1, 2], "B": [3, 4]})
+        df2 = _pd.DataFrame({"Period": [1, 2], "Time": [1, 2], "C": [5, 6]})
+        df3 = _pd.DataFrame({"Period": [1, 2], "Time": [3, 2], "D": [7, 8]})
+
+        result = ps.handle_duplicate_columns(
+            _pd.concat([df1, df2, df3], axis=1)
+        )
+        expected = _pd.DataFrame(
+            {"Period": [1, 2], "B": [3, 4], "C": [5, 6], "D": [7, 8]}
+        )
+        _pd.testing.assert_frame_equal(result, expected)
+
     def test_handle_with_matching_none_duplicates(self):
         """Test merging of duplicate columns with null values."""
         df1 = _pd.DataFrame({"A": [None, 2], "B": [3, 4]})


### PR DESCRIPTION
The Time column is now removed, if a conflict is found between Time columns, as long as the other column (Month, Period, or TIME) does not have such a conflict.